### PR TITLE
feat: Sync Main and Beta Branches

### DIFF
--- a/.github/workflows/sync_branches.yml
+++ b/.github/workflows/sync_branches.yml
@@ -1,0 +1,35 @@
+name: Sync Branches with Main
+
+on:
+  push:
+    branches:
+      - main-gha-test
+
+jobs:
+  sync-beta-with-main:
+    runs-on: ubuntu-latest
+    name: Sync Beta branch with Main
+    steps:
+
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.MESOSPHERECI_USER_TOKEN }}
+
+      - name: Import GPG key
+        uses: crazy-max/ghaction-import-gpg@v4
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+          git_user_signingkey: true
+          git_commit_gpgsign: true
+          git_tag_gpgsign: true
+          git_config_global: true
+
+      - name: Opening pull request in Beta branch
+        id: pull
+        uses: tretuna/sync-branches@1.2.0
+        with:
+          GITHUB_TOKEN: ${{ secrets.MESOSPHERECI_USER_TOKEN }}
+          FROM_BRANCH: 'main-gha-test'
+          TO_BRANCH: 'beta-gha-test'


### PR DESCRIPTION
Add GHA to sync main and beta branches.

Testing:
We're using these two branches:
- `main-gha-test` branched off `main`
- `beta-gha-test` branched off `beta`

We will then issue commits to `main-gha-test` and monitor PRs on `beta-gha-test`. Once this code is tested, these branches will be modified to use `main` and `beta` respectively.
