### PR TITLE
fix: Use downloads.d2iq.com instead of downloads.mesosphere.io

### DIFF
--- a/make/release.mk
+++ b/make/release.mk
@@ -3,7 +3,7 @@ IMAGE_TAR_FILE := $(BUILD_DIR)/dkp-insights-image-bundle.tar
 REPO_ARCHIVE_FILE := $(BUILD_DIR)/dkp-insights.tar.gz
 CATALOG_IMAGES_TXT := $(BUILD_DIR)/dkp_insights_images.txt
 INSIGHTS_CATALOG_APPLICATIONS_CHART_BUNDLE := $(BUILD_DIR)/dkp-insights-charts-bundle.tar.gz
-RELEASE_S3_BUCKET ?= downloads.mesosphere.io
+RELEASE_S3_BUCKET ?= downloads.d2iq.com
 
 CATALOG_APPLICATIONS_VERSION ?= ""
 

--- a/make/tools.mk
+++ b/make/tools.mk
@@ -33,7 +33,7 @@ bloodhound: $(DKP_BLOODHOUND_BIN)
 $(DKP_BLOODHOUND_BIN):
 	$(call print-target)
 	mkdir -p $(dir $@) _install
-	curl -fsSL https://downloads.mesosphere.io/dkp-bloodhound/dkp-bloodhound_v$(DKP_BLOODHOUND_VERSION)_$(GOOS)_$(GOARCH).tar.gz | tar xz -C _install 'dkp-bloodhound'
+	curl -fsSL https://downloads.d2iq.com/dkp-bloodhound/dkp-bloodhound_v$(DKP_BLOODHOUND_VERSION)_$(GOOS)_$(GOARCH).tar.gz | tar xz -C _install 'dkp-bloodhound'
 	mv _install/dkp-bloodhound $@
 	chmod 755 $@
 	rm -rf _install
@@ -45,7 +45,7 @@ dkp-cli: $(DKP_CLI_BIN)
 $(DKP_CLI_BIN):
 	$(call print-target)
 	mkdir -p $(dir $@) _install
-	curl -fsSL https://downloads.mesosphere.io/dkp/$(DKP_CLI_VERSION)/dkp_$(DKP_CLI_VERSION)_$(GOOS)_$(GOARCH).tar.gz | tar xz -C _install 'dkp'
+	curl -fsSL https://downloads.d2iq.com/dkp/$(DKP_CLI_VERSION)/dkp_$(DKP_CLI_VERSION)_$(GOOS)_$(GOARCH).tar.gz | tar xz -C _install 'dkp'
 	mv _install/dkp $@
 	chmod 755 $@
 	rm -rf _install


### PR DESCRIPTION
Remove use of deprecated downloads.mesosphere.io