### PR TITLE
fix: Revert upload bucket name to downloads.mesosphere.io

### DIFF
--- a/make/release.mk
+++ b/make/release.mk
@@ -3,7 +3,7 @@ IMAGE_TAR_FILE := $(BUILD_DIR)/dkp-insights-image-bundle.tar
 REPO_ARCHIVE_FILE := $(BUILD_DIR)/dkp-insights.tar.gz
 CATALOG_IMAGES_TXT := $(BUILD_DIR)/dkp_insights_images.txt
 INSIGHTS_CATALOG_APPLICATIONS_CHART_BUNDLE := $(BUILD_DIR)/dkp-insights-charts-bundle.tar.gz
-RELEASE_S3_BUCKET ?= downloads.d2iq.com
+RELEASE_S3_BUCKET ?= downloads.mesosphere.io
 
 CATALOG_APPLICATIONS_VERSION ?= ""
 


### PR DESCRIPTION
Revert to previous bucket name as builds will fail with downloads.d2iq.com, as seen on this [TC Build](https://teamcity.mesosphere.io/buildConfiguration/ClosedSource_Kommander2_InsightsCatalogApplications_ReleaseImageBundle/3813209?buildTab=log&focusLine=3&linesState=816).

Related [Slack Thread](https://d2iq.slack.com/archives/C5U03P5T6/p1675449754444559)