### PR TITLE
feat: Move repo's CI builds into GHA

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -1,0 +1,61 @@
+name: Continuous Integration
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    tags:
+      - 'v*'
+    branches:
+      - 'main'
+
+jobs:
+  pre-commit:
+    name: Pre-Commit Checks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.MERGEBOT_TOKEN }}
+
+      - name: Pre-commit Checks
+        run: make ci.docker.run GOOS=linux GOARCH=amd64 RUN_WHAT="env SKIP=no-commit-to-branch make pre-commit"
+
+  unit-test:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.MERGEBOT_TOKEN }}
+
+      - name: Run Unit Tests
+        run: make ci.docker.run GOOS=linux GOARCH=amd64 RUN_WHAT="make test"
+
+  build-image-bundle:
+    name: Build Image Bundle
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.MERGEBOT_TOKEN }}
+
+      - name: Build Image Bundle
+        run: make ci.docker.run GOOS=linux GOARCH=amd64 RUN_WHAT="make release.save-images.tar"
+
+  push-ci-docker-image:
+    name: Push CI Docker Image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.MERGEBOT_TOKEN }}
+
+      - name: Push Image
+        env:
+          DOCKER_USERNAME: ${{ secrets.DOCKER_READ_WRITE_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_READ_WRITE_PASSWORD }}
+        run: make ci.docker.run RUN_WHAT="make ci.docker.push"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,79 @@
+name: Release
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  release:
+    name: Release
+    permissions:
+      actions: write
+      checks: write
+      contents: write
+      deployments: write
+      discussions: write
+      id-token: write
+      issues: write
+      packages: write
+      pages: write
+      pull-requests: write
+      repository-projects: write
+      security-events: write
+      statuses: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set Env Variables
+        run: |
+          current_branch=${GITHUB_REF#refs/tags/}
+          set +e
+          PRERELEASE_BUILDMETADATA=$(echo ${current_branch} | perl -ne 'print "$4$5" if /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/')
+          set -e
+          if [ ! -z ${PRERELEASE_BUILDMETADATA} ]
+          then
+            checkout_branch=beta
+          else
+            checkout_branch=main
+          fi
+          echo "BUILD_BRANCH=$current_branch" >> $GITHUB_ENV
+          echo "CHECKOUT_BRANCH=$checkout_branch" >> $GITHUB_ENV
+          echo "SLACK_WEBHOOK=${{ secrets.ENG_SHIPIT_WEBHOOK_URL }}" >> $GITHUB_ENV
+
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.MERGEBOT_TOKEN }}
+
+      - name: Configure git for private repo access
+        if: ${{ github.actor != 'dependabot[bot]' }}
+        run: git config --global url.https://${{ secrets.MERGEBOT_TOKEN }}@github.com/.insteadOf https://github.com/
+
+      - name: Install AWS cli
+        uses: unfor19/install-aws-cli-action@v1.0.3
+        with:
+          arch: amd64
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: arn:aws:iam::633059600857:role/insights-catalog-applications
+          aws-region: us-east-1
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Release Repo Archive
+        run: make ci.docker.run GOOS=linux GOARCH=amd64 RUN_WHAT="make release.repo-archive CATALOG_APPLICATIONS_VERSION=${{ env.BUILD_BRANCH }} INSIGHTS_CATALOG_APPLICATIONS_REF=${{ env.CHECKOUT_BRANCH }}"
+
+      - name: Release Charts Bundle
+        run: make ci.docker.run GOOS=linux GOARCH=amd64 RUN_WHAT="make release.charts-bundle INSIGHTS_CATALOG_APPLICATIONS_REF=${{ env.CHECKOUT_BRANCH }}"
+
+      - name: Release Save Images
+        run: make ci.docker.run GOOS=linux GOARCH=amd64 RUN_WHAT="make release.save-images.tar INSIGHTS_CATALOG_APPLICATIONS_REF=${{ env.CHECKOUT_BRANCH }}"
+
+      - name: Release S3
+        run: make ci.docker.run GOOS=linux GOARCH=amd64 RUN_WHAT="make release.s3 CATALOG_APPLICATIONS_VERSION=${{ env.BUILD_BRANCH }} INSIGHTS_CATALOG_APPLICATIONS_REF=${{ env.CHECKOUT_BRANCH }}"

--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,7 @@ pre-commit: ; $(info $(M) running pre-commit)
 ifeq ($(wildcard $(PRE_COMMIT_CONFIG_FILE)),)
 	$(error Cannot find pre-commit config file $(PRE_COMMIT_CONFIG_FILE). Specify the config file via PRE_COMMIT_CONFIG_FILE variable)
 endif
+	git config --global --add safe.directory $(REPO_ROOT)
 	env SKIP=$(SKIP) pre-commit run -a --show-diff-on-failure --config $(PRE_COMMIT_CONFIG_FILE)
 	git fetch origin main && gitlint --ignore-stdin --commits origin/main..HEAD
 

--- a/make/release.mk
+++ b/make/release.mk
@@ -23,6 +23,7 @@ release.repo-archive: $(BUILD_DIR)
 ifeq ($(CATALOG_APPLICATIONS_VERSION),"")
 	$(info CATALOG_APPLICATIONS_VERSION should be set to the version which is part of the s3 file path)
 else
+	git config --global --add safe.directory $(REPO_ROOT)
 	git archive --format "tar.gz" -o $(REPO_ARCHIVE_FILE) \
 	                              $(CATALOG_APPLICATIONS_VERSION) -- \
 	                              helm-repositories services


### PR DESCRIPTION
# Description
Bringing all CI builds for this repo [from TC](https://teamcity.mesosphere.io/admin/editProject.html?projectId=ClosedSource_Kommander2_InsightsCatalogApplications) to GH Actions


## Which issue(s) does this PR relate to?
Relates to [D2IQ-95929](https://d2iq.atlassian.net/browse/D2IQ-95929)

## Testing
- Pre-commit checks build passing - 🔴  (atm failing with a lint error - [build](https://github.com/mesosphere/insights-catalog-applications/actions/runs/4188546181/jobs/7259819015))
- Unit tests build passing - ✅ 
- Build Image Bundle build passing - ✅ 
- Push CI docker image build passing - ✅ 
- Release build passing - ✅ ([build](https://github.com/mesosphere/insights-catalog-applications/actions/runs/4193594413))

## Trade-offs
N/A

## Screenshots
N/A

## Checklist

- [ ] This PR is associated with a JIRA and mentions in the commit message footer ("Closes …")
- [ ] This PR contains breaking changes and states in the commit message body ("BREAKING CHANGE: …")

[D2IQ-95929]: https://d2iq.atlassian.net/browse/D2IQ-95929?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ